### PR TITLE
explicitly detect `BuildFinishedEventArgs` and return from pipe reading

### DIFF
--- a/MsBuildPipeLogger.sln
+++ b/MsBuildPipeLogger.sln
@@ -5,8 +5,6 @@ VisualStudioVersion = 15.0.27703.2000
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{5CC6B5A3-CF3A-463D-8116-D02280B6F6A2}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{812B67C9-1716-4583-B2FF-25C1715D0C58}"
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "misc", "misc", "{2ACFADCF-39EE-4CD6-B649-BCF364A3B0AB}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
@@ -26,15 +24,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MsBuildPipeLogger.Logger", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MsBuildPipeLogger.Server", "src\MsBuildPipeLogger.Server\MsBuildPipeLogger.Server.csproj", "{19286807-751C-43CE-891A-6E9B9CB7200C}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MsBuildPipeLogger.Tests", "tests\MsBuildPipeLogger.Tests\MsBuildPipeLogger.Tests.csproj", "{F70DD8B5-DAE2-4D6F-9BBC-A0E64378EAA1}"
-	ProjectSection(ProjectDependencies) = postProject
-		{2C6D9150-3CA3-4499-A08C-98A12F76757F} = {2C6D9150-3CA3-4499-A08C-98A12F76757F}
-	EndProjectSection
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MsBuildPipeLogger.Tests.Client", "tests\MsBuildPipeLogger.Tests.Client\MsBuildPipeLogger.Tests.Client.csproj", "{2C6D9150-3CA3-4499-A08C-98A12F76757F}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MsBuildPipeLogger.Logger.Tests", "tests\MsBuildPipeLogger.Logger.Tests\MsBuildPipeLogger.Logger.Tests.csproj", "{65721127-A8F7-4DA0-9FAF-1D028C4A6900}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -49,18 +38,6 @@ Global
 		{19286807-751C-43CE-891A-6E9B9CB7200C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{19286807-751C-43CE-891A-6E9B9CB7200C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{19286807-751C-43CE-891A-6E9B9CB7200C}.Release|Any CPU.Build.0 = Release|Any CPU
-		{F70DD8B5-DAE2-4D6F-9BBC-A0E64378EAA1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F70DD8B5-DAE2-4D6F-9BBC-A0E64378EAA1}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F70DD8B5-DAE2-4D6F-9BBC-A0E64378EAA1}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F70DD8B5-DAE2-4D6F-9BBC-A0E64378EAA1}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2C6D9150-3CA3-4499-A08C-98A12F76757F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2C6D9150-3CA3-4499-A08C-98A12F76757F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2C6D9150-3CA3-4499-A08C-98A12F76757F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{2C6D9150-3CA3-4499-A08C-98A12F76757F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{65721127-A8F7-4DA0-9FAF-1D028C4A6900}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{65721127-A8F7-4DA0-9FAF-1D028C4A6900}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{65721127-A8F7-4DA0-9FAF-1D028C4A6900}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{65721127-A8F7-4DA0-9FAF-1D028C4A6900}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -68,9 +45,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{F7DEEDA0-B1EB-4A4C-B102-367A73AB5F4A} = {5CC6B5A3-CF3A-463D-8116-D02280B6F6A2}
 		{19286807-751C-43CE-891A-6E9B9CB7200C} = {5CC6B5A3-CF3A-463D-8116-D02280B6F6A2}
-		{F70DD8B5-DAE2-4D6F-9BBC-A0E64378EAA1} = {812B67C9-1716-4583-B2FF-25C1715D0C58}
-		{2C6D9150-3CA3-4499-A08C-98A12F76757F} = {812B67C9-1716-4583-B2FF-25C1715D0C58}
-		{65721127-A8F7-4DA0-9FAF-1D028C4A6900} = {812B67C9-1716-4583-B2FF-25C1715D0C58}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A3E97697-C563-4DFF-9360-F7E48E991421}

--- a/src/MsBuildPipeLogger.Logger/MsBuildPipeLogger.Logger.csproj
+++ b/src/MsBuildPipeLogger.Logger/MsBuildPipeLogger.Logger.csproj
@@ -1,19 +1,32 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     <RootNamespace>MsBuildPipeLogger</RootNamespace>
-    <Authors>Dave Glick</Authors>
+    <Authors>Dave Glick (patched by Leandro)</Authors>
     <Company>Dave Glick</Company>
     <Product />
     <Description>A logger for MSBuild that sends event data over anonymous or named pipes.</Description>
-    <PackageProjectUrl>https://msbuildpipelogger.netlify.com/</PackageProjectUrl>
+    <PackageProjectUrl>https://www.shiftleft.io/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/daveaglick/MsBuildPipeLogger.git</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageId>SL_MsbuildPipeLogger.Logger</PackageId>
+    <Owners>ShiftLeft Inc</Owners>
+    <PackOnBuild>true</PackOnBuild>
+    <PackageVersion>1.0.1</PackageVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType></DebugType>
+    <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="14.3.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="14.3.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build" Version="16.10.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.10.0" PrivateAssets="All" />
     <PackageReference Include="System.IO.Pipes" Version="4.3.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
   </ItemGroup>

--- a/src/MsBuildPipeLogger.Server/MsBuildPipeLogger.Server.csproj
+++ b/src/MsBuildPipeLogger.Server/MsBuildPipeLogger.Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.5</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>MsBuildPipeLogger</RootNamespace>
     <Authors>Dave Glick</Authors>
     <Company>Dave Glick</Company>

--- a/src/MsBuildPipeLogger.Server/MsBuildPipeLogger.Server.csproj
+++ b/src/MsBuildPipeLogger.Server/MsBuildPipeLogger.Server.csproj
@@ -3,13 +3,22 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>MsBuildPipeLogger</RootNamespace>
-    <Authors>Dave Glick</Authors>
+    <Authors>Dave Glick (patched by Leandro)</Authors>
     <Company>Dave Glick</Company>
     <Product />
     <Description>A logger for MSBuild that sends event data over anonymous or named pipes.</Description>
-    <PackageProjectUrl>https://msbuildpipelogger.netlify.com/</PackageProjectUrl>
+    <PackageProjectUrl>https://www.shiftleft.io/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/daveaglick/MsBuildPipeLogger.git</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackOnBuild>true</PackOnBuild>
+    <PackageId>SL_MsbuildPipeLogger.Server</PackageId>
+    <Owners>ShiftLeft Inc</Owners>
+    <Configurations>Release;Debug</Configurations>
+    <PackageVersion>1.0.1</PackageVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType></DebugType>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="15.3.409" />

--- a/src/MsBuildPipeLogger.Server/PipeLoggerServer.cs
+++ b/src/MsBuildPipeLogger.Server/PipeLoggerServer.cs
@@ -101,8 +101,14 @@ namespace MsBuildPipeLogger
         /// <inheritdoc/>
         public void ReadAll()
         {
-            while (Read() != null)
+            BuildEventArgs args = Read();
+            while (args != null)
             {
+                if (args is BuildFinishedEventArgs)
+                {
+                    return;
+                }
+                args = Read();
             }
         }
 
@@ -110,6 +116,7 @@ namespace MsBuildPipeLogger
         public void Dispose()
         {
             _binaryReader.Dispose();
+            Buffer.Dispose();
             PipeStream.Dispose();
         }
     }

--- a/tests/MsBuildPipeLogger.Logger.Tests/MsBuildPipeLogger.Logger.Tests.csproj
+++ b/tests/MsBuildPipeLogger.Logger.Tests/MsBuildPipeLogger.Logger.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="15.8.166" />

--- a/tests/MsBuildPipeLogger.Tests.Client/MsBuildPipeLogger.Tests.Client.csproj
+++ b/tests/MsBuildPipeLogger.Tests.Client/MsBuildPipeLogger.Tests.Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Build" Version="15.8.166" />

--- a/tests/MsBuildPipeLogger.Tests/MsBuildPipeLogger.Tests.csproj
+++ b/tests/MsBuildPipeLogger.Tests/MsBuildPipeLogger.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />


### PR DESCRIPTION
Hi @daveaglick , I recently upgraded to 3.0.0 (and 3.0.1) of [Buildalyzer](https://github.com/daveaglick/Buildalyzer) but bumped into an issue: 

- the MSBuild pipe logger is hanging for certain apps of my testing pipeline.

Interestingly, all cases where I spotted the problem were upon a `BuildFinishedEventArgs`. So a temporary "solution" I found was to explicitly detect such event and return upon it.

This does **not** eliminate the hanging, but at least it allows for me reach the a `finally` in my `Main` function and call `Environment.Exit(code)`.

Do you have any idea of what could be going on?
