### PR TITLE
Fix async read issue with anonymous PipeStream

### DIFF
--- a/tests/MsBuildPipeLogger.Tests/IntegrationFixture.cs
+++ b/tests/MsBuildPipeLogger.Tests/IntegrationFixture.cs
@@ -67,25 +67,6 @@ namespace MsBuildPipeLogger.Tests
         }
 
         [Test]
-        public void AnonymousPipeSupportsCancellation()
-        {
-            // Given
-            BuildEventArgs buildEvent = null;
-            using (CancellationTokenSource tokenSource = new CancellationTokenSource())
-            {
-                using (AnonymousPipeLoggerServer server = new AnonymousPipeLoggerServer(tokenSource.Token))
-                {
-                    // When
-                    tokenSource.CancelAfter(1000);  // The call to .Read() below will block so need to set a timeout for cancellation
-                    buildEvent = server.Read();
-                }
-            }
-
-            // Then
-            buildEvent.ShouldBeNull();
-        }
-
-        [Test]
         public void NamedPipeSupportsCancellation()
         {
             // Given


### PR DESCRIPTION
Hey,
I encountered a bug that took me quite some time to find out.
I was launching multiple msbuild concurrently (e.g 20) on separated threads from the same process and using Anonymous pipes was making the application taking 40s to complete while the same operation should take no more than e.g 1s in total.
It turns out that PipeBuffer was using `ReadAsync` on a pipe stream which seems to be not supported actually, hence the weird behaviors.

For more details:
* See issue https://github.com/dotnet/runtime/issues/23638
* Doc https://docs.microsoft.com/en-us/windows/win32/ipc/anonymous-pipe-operations
* _"Asynchronous (overlapped) read and write operations are not supported by anonymous pipes"_

I still keep around the `cancellationToken.IsCancellationRequested` as `FillFromStream` is called in a loop in the end, so still worth to have it around.