### PR TITLE
Fix PipeLoggerServer.ReadAll() to detect BuildFinishedEventArgs

### DIFF
--- a/src/MsBuildPipeLogger.Server/PipeLoggerServer.cs
+++ b/src/MsBuildPipeLogger.Server/PipeLoggerServer.cs
@@ -101,8 +101,14 @@ namespace MsBuildPipeLogger
         /// <inheritdoc/>
         public void ReadAll()
         {
-            while (Read() != null)
+            BuildEventArgs args = Read();
+            while (args != null)
             {
+                if (args is BuildFinishedEventArgs)
+                {
+                    return;
+                }
+                args = Read();
             }
         }
 
@@ -110,6 +116,7 @@ namespace MsBuildPipeLogger
         public void Dispose()
         {
             _binaryReader.Dispose();
+            Buffer.Dispose();
             PipeStream.Dispose();
         }
     }


### PR DESCRIPTION
A fix for #2, but separated from net6.0 upgrade