### PR TITLE
Fix Unhandled Interrupted system call in PipeLoggerServer 

### DIFF
--- a/src/MsBuildPipeLogger.Logger/PipeWriter.cs
+++ b/src/MsBuildPipeLogger.Logger/PipeWriter.cs
@@ -28,7 +28,7 @@ namespace MsBuildPipeLogger
             _binaryWriter = new BinaryWriter(_memoryStream);
             _argsWriter = new BuildEventArgsWriter(_binaryWriter);
 
-            new Thread(() =>
+            Thread writerThread = new Thread(() =>
             {
                 BuildEventArgs eventArgs;
                 while ((eventArgs = TakeEventArgs()) != null)
@@ -46,7 +46,11 @@ namespace MsBuildPipeLogger
                     _pipeStream.Flush();
                 }
                 _doneProcessing.Set();
-            }).Start();
+            })
+            {
+                IsBackground = true,
+            };
+            writerThread.Start();
         }
 
         private BuildEventArgs TakeEventArgs()

--- a/src/MsBuildPipeLogger.Server/PipeLoggerServer.cs
+++ b/src/MsBuildPipeLogger.Server/PipeLoggerServer.cs
@@ -46,7 +46,7 @@ namespace MsBuildPipeLogger
             _buildEventArgsReader = new BuildEventArgsReaderProxy(_binaryReader);
             CancellationToken = cancellationToken;
 
-            new Thread(() =>
+            Thread readerThread = new Thread(() =>
             {
                 try
                 {
@@ -68,7 +68,12 @@ namespace MsBuildPipeLogger
                 Buffer.Write(new byte[1] { 0 }, 0, 1);
 
                 Buffer.CompleteAdding();
-            }).Start();
+            })
+            {
+                IsBackground = true
+            };
+
+            readerThread.Start();
         }
 
         protected abstract void Connect();

--- a/src/MsBuildPipeLogger.Server/PipeLoggerServer.cs
+++ b/src/MsBuildPipeLogger.Server/PipeLoggerServer.cs
@@ -55,7 +55,7 @@ namespace MsBuildPipeLogger
                     {
                     }
                 }
-                catch (EndOfStreamException)
+                catch (IOException)
                 {
                     // The client broke the stream so we're done
                 }


### PR DESCRIPTION
Fixes #8

Replacing the narrow catch with a wider catch on `IOException` and it is fixing the issue.